### PR TITLE
Search for mastodon account instead of link.

### DIFF
--- a/confirm.php
+++ b/confirm.php
@@ -29,7 +29,7 @@
             else { break; }
         }
 		
-		preg_match("(<div class=\"tweet-content media-body\" dir=\"auto\">.+?".$mastodon_link.".+?Twittodon.com)is", $site_source_code, $phrase);
+		preg_match("(<div class=\"tweet-content media-body\" dir=\"auto\">.+?".$mastodon.".+?Twittodon.com)is", $site_source_code, $phrase);
 
 		if(!empty($phrase[0]))
 		{


### PR DESCRIPTION
Elon just banned posting Mastodon links on Twitter. This PR should work around this. Note I haven't tested this yet. I've not worked with PHP in ages, but this is an awesome project and I figured I'd try to help out.